### PR TITLE
Add retries to deb file download

### DIFF
--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -2,6 +2,8 @@
 
 remote_file "#{Chef::Config[:file_cache_path]}/sumocollector.deb" do
   source node['sumologic']['collectorDEBUrl']
+  retries 5
+  retry_delay 2
 end
 
 dpkg_package 'sumocollector' do


### PR DESCRIPTION
This is starting to intermittently fail all the time, so add retries.  See chef docs here for these option descriptions:  https://docs.chef.io/resource_remote_file.html.  Note that I've added the "retry_delay" setting redundantly to the default just to make it clear what the setting is here.

It's possible that these won't work on our older chef version, but I'm willing to take the hit testing these just because of how much of an issue this has become.